### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/common.js
+++ b/common.js
@@ -18,7 +18,7 @@ Common = {
     S: require('string'),
     username: require('username').sync(),
     os: require('os').platform(),
-    uuid: require('node-uuid'),
+    uuid: require('uuid'),
     ip: require('ip'),
     path: require('path'),
     validator: require('validator'),

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "jade": "*",
     "mkdirp": "0.5.0",
     "moment": "2.7.0",
-    "node-uuid": "~1.4.1",
     "nodejs-model": "~0.1.6",
     "nodemailer": "^1.4.0",
     "nodemailer-mandrill-transport": "^0.3.0",
@@ -62,6 +61,7 @@
     "underscore": "~1.6.0",
     "user-settings": "*",
     "username": "0.1.1",
+    "uuid": "^3.0.0",
     "validator": "~3.22.1",
     "winston": "^1.0.2"
   },

--- a/util/temp-write.js
+++ b/util/temp-write.js
@@ -3,7 +3,7 @@ var path = require('path');
 var tmpdir = 'public/tmp';
 var fs = require('graceful-fs');
 var mkdirp = require('mkdirp');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var rimraf = require('rimraf');
 
 function tempfile(filepath) {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.